### PR TITLE
use proper OUT_DIR for faster rebuilds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,6 +247,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
 
 [[package]]
+name = "fs_extra"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,6 +431,7 @@ dependencies = [
  "bindgen",
  "clippy",
  "easy-parallel",
+ "fs_extra",
  "itertools",
  "pretty_assertions",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ clippy = { version = "*", optional = true }
 prost-build = "*"
 serde = { version = "*", features = ["derive"] }
 serde_json = "*"
+fs_extra = "*"
 
 [dev-dependencies]
 easy-parallel = "*"

--- a/build.rs
+++ b/build.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Configure cargo through stdout
     println!("cargo:rerun-if-changed={}", makefile_path.display()); // Includes version number
-    println!("cargo:rustc-link-search=native={}", build_path.display());
+    println!("cargo:rustc-link-search=native={}", out_dir.display());
     println!("cargo:rustc-link-lib=static={}", LIBRARY_NAME);
 
     // Copy the relevant source files to the OUT_DIR

--- a/build.rs
+++ b/build.rs
@@ -1,30 +1,63 @@
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 
+use fs_extra::dir::CopyOptions;
 use std::env;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
-fn main() {
-    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+static SOURCE_DIRECTORY: &str = "libpg_query";
+static LIBRARY_NAME: &str = "pg_query";
 
-    println!("cargo:rerun-if-changed=./libpg_query/Makefile"); // Includes version number
-    println!("cargo:rustc-link-search=native=./libpg_query");
-    println!("cargo:rustc-link-lib=static=pg_query");
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let out_dir = PathBuf::from(env::var("OUT_DIR")?);
+    let build_path = Path::new(".").join(SOURCE_DIRECTORY);
+    let makefile_path = build_path.join("Makefile");
+    let out_header_path = out_dir.join(LIBRARY_NAME).with_extension("h");
+    let out_protobuf_path = out_dir.join("protobuf");
+
+    // Configure cargo through stdout
+    println!("cargo:rerun-if-changed={}", makefile_path.display()); // Includes version number
+    println!("cargo:rustc-link-search=native={}", build_path.display());
+    println!("cargo:rustc-link-lib=static={}", LIBRARY_NAME);
+
+    // Copy the relevant source files to the OUT_DIR
+    let source_paths = vec![
+        build_path.join(LIBRARY_NAME).with_extension("h"),
+        build_path.join("Makefile"),
+        build_path.join("src"),
+        build_path.join("protobuf"),
+        build_path.join("vendor"),
+    ];
+
+    let copy_options = CopyOptions { overwrite: true, ..CopyOptions::default() };
+
+    fs_extra::copy_items(&source_paths, &out_dir, &copy_options)?;
 
     // Compile the C library.
     let mut make = Command::new("make");
-    make.current_dir("libpg_query");
+
+    make.env_remove("PROFILE").arg("-C").arg(&out_dir).arg("build");
+
     if env::var("PROFILE").unwrap() == "debug" {
         make.arg("DEBUG=1");
     }
-    let status = make.stdin(Stdio::null()).stdout(Stdio::inherit()).stderr(Stdio::inherit()).status().unwrap();
-    assert!(status.success());
+
+    let status = make.stdin(Stdio::null()).stdout(Stdio::inherit()).stderr(Stdio::inherit()).status()?;
+
+    if !status.success() {
+        return Err("libpg_query compilation failed".into());
+    }
 
     // Generate bindings for Rust
-    let bindings = bindgen::Builder::default().header("./libpg_query/pg_query.h").generate().expect("Unable to generate bindings");
-    bindings.write_to_file(out_dir.join("bindings.rs")).expect("Couldn't write bindings!");
+    bindgen::Builder::default()
+        .header(out_header_path.to_str().ok_or("Invalid header path")?)
+        .generate()
+        .map_err(|_| "Unable to generate bindings")?
+        .write_to_file(out_dir.join("bindings.rs"))?;
 
     // Generate the protobuf definition
-    prost_build::compile_protos(&["./libpg_query/protobuf/pg_query.proto"], &["./libpg_query/protobuf"]).expect("protobuf generation failed");
+    prost_build::compile_protos(&[&out_protobuf_path.join(LIBRARY_NAME).with_extension("proto")], &[&out_protobuf_path])?;
+
+    Ok(())
 }


### PR DESCRIPTION
According to the `cargo` book, any output from build scripts should be [placed in the `OUT_DIR` directory](https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script). The current build script on `main` modifies assets in-place without respecting `OUT_DIR`, which might interfere with re-run logic from tools like `cargo watch`.

This PR brings back the `OUT_DIR`, but tries to minimize the number of files brought over on each rebuild. In practice (on my machine), this has eliminated some of the flakiness around `cargo watch` when working with the `main` branch, and has reduced fresh build times from ~30s to ~10s.