### PR TITLE
Truncate bugfixes

### DIFF
--- a/tests/truncate_tests.rs
+++ b/tests/truncate_tests.rs
@@ -73,3 +73,19 @@ fn it_handles_GRANT() {
     let result = parse(query).unwrap();
     assert_eq!(result.truncate(35).unwrap(), "GRANT select (abc, def, ghj) ON ...")
 }
+
+#[test]
+fn it_handles_functions() {
+    let query = r#"
+        WITH activity AS (
+            SELECT pid, COALESCE(a.usename, '') AS usename
+            FROM pganalyze.get_stat_activity() a
+        )
+        SELECT
+        FROM pganalyze.get_stat_progress_vacuum() v
+        JOIN activity a USING (pid)
+    "#;
+    let result = parse(query).unwrap();
+    let truncated = result.truncate(100).unwrap();
+    assert_eq!(truncated, "WITH activity AS (...) SELECT FROM pganalyze.get_stat_progress_vacuum() v JOIN activity a USING (...");
+}


### PR DESCRIPTION
This fixes accidental memory corruption leading to segfaults. When truncating a CTE we need to remove its nested target list truncation from the list of possibilities, otherwise we'll end up referencing an object that no longer exists. This PR uses [`std::mem::replace`](https://doc.rust-lang.org/std/mem/fn.replace.html) to return the previous `SelectStmt` so it can be removed from `truncations` before the next iteration.

Two other bugfixes:
- don't attempt truncating target lists when they're empty (accidentally adds a `...` which just makes the query longer)
- if node truncations aren't sufficient, apply simple truncation as a fallback on the node-truncated string instead of on the source string

Review question: are there other truncation types where we could run into memory corruption? I tried subqueries in both `SELECT` and `FROM` and couldn't trigger another segfault.