### PR TITLE
Truncate on conflict bugfixes

### DIFF
--- a/src/parse_result.rs
+++ b/src/parse_result.rs
@@ -235,7 +235,7 @@ impl ParseResult {
     /// ```rust
     /// let query = "INSERT INTO \"x\" (a, b, c, d, e, f) VALUES (?)";
     /// let result = pg_query::parse(query).unwrap();
-    /// assert_eq!(result.truncate(32).unwrap(), "INSERT INTO x (...) VALUES (?)")
+    /// assert_eq!(result.truncate(32).unwrap(), "INSERT INTO x (...) VALUES (...)")
     /// ```
     pub fn truncate(&self, max_length: usize) -> Result<String> {
         crate::truncate(&self.protobuf, max_length)

--- a/src/truncate.rs
+++ b/src/truncate.rs
@@ -6,6 +6,7 @@ use crate::*;
 enum TruncationAttr {
     TargetList,
     WhereClause,
+    ValuesLists,
     CTEQuery,
     Cols,
 }
@@ -53,6 +54,14 @@ pub fn truncate(protobuf: &protobuf::ParseResult, max_length: usize) -> Result<S
                             node: node,
                             depth: depth,
                             length: where_clause_len((*clause).clone())?,
+                        });
+                    }
+                    if s.values_lists.len() > 0 {
+                        truncations.push(PossibleTruncation {
+                            attr: TruncationAttr::ValuesLists,
+                            node: node,
+                            depth: depth,
+                            length: select_values_lists_len(s.values_lists.clone())?,
                         });
                     }
                 }
@@ -191,6 +200,16 @@ pub fn truncate(protobuf: &protobuf::ParseResult, max_length: usize) -> Result<S
                     let s = s.as_mut().ok_or(Error::InvalidPointer)?;
                     s.where_clause = Some(dummy_column());
                 }
+                (NodeMut::SelectStmt(s), TruncationAttr::ValuesLists) => {
+                    let s = s.as_mut().ok_or(Error::InvalidPointer)?;
+                    s.values_lists = vec![
+                        Node {
+                            node: Some(NodeEnum::List(protobuf::List {
+                                items: vec![*dummy_column()]
+                            })),
+                        }
+                    ]
+                }
                 (NodeMut::UpdateStmt(s), TruncationAttr::TargetList) => {
                     let s = s.as_mut().ok_or(Error::InvalidPointer)?;
                     s.target_list = vec![dummy_target()];
@@ -221,7 +240,7 @@ pub fn truncate(protobuf: &protobuf::ParseResult, max_length: usize) -> Result<S
                 }
                 (NodeMut::CommonTableExpr(s), TruncationAttr::CTEQuery) => {
                     let s = s.as_mut().ok_or(Error::InvalidPointer)?;
-                    let old = std::mem::replace(&mut s.ctequery, Some(dummy_select(vec![], Some(dummy_column()))));
+                    let old = std::mem::replace(&mut s.ctequery, Some(dummy_select(vec![], Some(dummy_column()), vec![])));
                     if let Some(s) = old {
                         let node = s.node.ok_or(Error::InvalidPointer)?;
                         truncations.retain(|t| t.node.to_enum().unwrap() != node);
@@ -256,12 +275,17 @@ pub fn truncate(protobuf: &protobuf::ParseResult, max_length: usize) -> Result<S
 }
 
 fn target_list_len(nodes: Vec<Node>) -> Result<i32> {
-    let fragment = dummy_select(nodes, None).deparse()?;
+    let fragment = dummy_select(nodes, None, vec![]).deparse()?;
+    Ok(fragment.len() as i32 - 7) // "SELECT "
+}
+
+fn select_values_lists_len(nodes: Vec<Node>) -> Result<i32> {
+    let fragment = dummy_select(vec![], None, nodes).deparse()?;
     Ok(fragment.len() as i32 - 7) // "SELECT "
 }
 
 fn where_clause_len(node: Box<Node>) -> Result<i32> {
-    let fragment = dummy_select(vec![], Some(node)).deparse()?;
+    let fragment = dummy_select(vec![], Some(node), vec![]).deparse()?;
     Ok(fragment.len() as i32 - 13) // "SELECT WHERE "
 }
 
@@ -290,7 +314,7 @@ fn dummy_target() -> Node {
     }
 }
 
-fn dummy_select(target_list: Vec<Node>, where_clause: Option<Box<Node>>) -> Box<Node> {
+fn dummy_select(target_list: Vec<Node>, where_clause: Option<Box<Node>>, values_lists: Vec<Node>) -> Box<Node> {
     Box::new(Node {
         node: Some(NodeEnum::SelectStmt(Box::new(protobuf::SelectStmt {
             distinct_clause: vec![],
@@ -301,7 +325,7 @@ fn dummy_select(target_list: Vec<Node>, where_clause: Option<Box<Node>>) -> Box<
             group_clause: vec![],
             having_clause: None,
             window_clause: vec![],
-            values_lists: vec![],
+            values_lists: values_lists,
             sort_clause: vec![],
             limit_offset: None,
             limit_count: None,

--- a/src/truncate.rs
+++ b/src/truncate.rs
@@ -202,13 +202,7 @@ pub fn truncate(protobuf: &protobuf::ParseResult, max_length: usize) -> Result<S
                 }
                 (NodeMut::SelectStmt(s), TruncationAttr::ValuesLists) => {
                     let s = s.as_mut().ok_or(Error::InvalidPointer)?;
-                    s.values_lists = vec![
-                        Node {
-                            node: Some(NodeEnum::List(protobuf::List {
-                                items: vec![*dummy_column()]
-                            })),
-                        }
-                    ]
+                    s.values_lists = vec![Node { node: Some(NodeEnum::List(protobuf::List { items: vec![*dummy_column()] })) }]
                 }
                 (NodeMut::UpdateStmt(s), TruncationAttr::TargetList) => {
                     let s = s.as_mut().ok_or(Error::InvalidPointer)?;

--- a/tests/truncate_tests.rs
+++ b/tests/truncate_tests.rs
@@ -28,7 +28,7 @@ fn it_omits_WHERE_clause() {
 fn it_omits_INSERT_field_list() {
     let query = "INSERT INTO \"x\" (a, b, c, d, e, f) VALUES (?)";
     let result = parse(query).unwrap();
-    assert_eq!(result.truncate(32).unwrap(), "INSERT INTO x (...) VALUES (?)")
+    assert_eq!(result.truncate(32).unwrap(), "INSERT INTO x (...) VALUES (...)")
 }
 
 #[test]

--- a/tests/truncate_tests.rs
+++ b/tests/truncate_tests.rs
@@ -67,6 +67,18 @@ fn it_omits_ON_CONFLICT_target_list() {
 }
 
 #[test]
+fn it_omits_ON_CONFLICT_target_list_2() {
+    let query = r#"
+        INSERT INTO foo (a, b, c, d) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29)
+        ON CONFLICT (id)
+        DO UPDATE SET (a, b, c, d) = (excluded.a,excluded.b,excluded.c,case when foo.d = excluded.d then excluded.d end)
+    "#;
+    let result = parse(query).unwrap();
+    let truncated = result.truncate(100).unwrap();
+    assert_eq!(truncated, "INSERT INTO foo (a, b, c, d) VALUES (...) ON CONFLICT (id) DO UPDATE SET ... = ...");
+}
+
+#[test]
 fn it_handles_GRANT() {
     let query = "GRANT SELECT (abc, def, ghj) ON TABLE t1 TO r1";
     let result = parse(query).unwrap();


### PR DESCRIPTION
```
Truncate: Simplify VALUES(...) lists
```

```
Truncate: Correctly handle UPDATE and ON CONFLICT target lists

These target list fields support MultiAssignRef nodes, which are not
supported in regular SELECT target lists - thus requiring special handling.
```