### PR TITLE
feat: split_with_parser, split_with_scanner

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -13,6 +13,8 @@ pub enum Error {
     InvalidJson(String),
     #[error("Invalid pointer")]
     InvalidPointer,
+    #[error("Error splitting: {0}")]
+    Split(String),
 }
 
 /// Convenient Result alias for returning `pg_query::Error`.

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,6 +13,8 @@ pub enum Error {
     InvalidJson(String),
     #[error("Invalid pointer")]
     InvalidPointer,
+    #[error("Error scanning: {0}")]
+    Scan(String),
     #[error("Error splitting: {0}")]
     Split(String),
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -3,7 +3,6 @@ use std::os::raw::{c_char, c_uint};
 
 use prost::Message;
 
-// use crate::scan_result::ScanResult;
 use crate::bindings::*;
 use crate::error::*;
 use crate::parse_result::ParseResult;

--- a/src/query.rs
+++ b/src/query.rs
@@ -167,9 +167,9 @@ pub fn parse_plpgsql(stmt: &str) -> Result<serde_json::Value> {
 }
 
 /// Split a well-formed query into separate statements.
-/// 
+///
 /// # Example
-/// 
+///
 /// ```rust
 /// let query = r#"select /*;*/ 1; select "2;", (select 3);"#;
 /// let statements = pg_query::split_with_parser(query).unwrap();
@@ -177,7 +177,7 @@ pub fn parse_plpgsql(stmt: &str) -> Result<serde_json::Value> {
 /// ```
 ///
 /// However, `split_with_parser` will fail on malformed statements
-/// 
+///
 /// ```rust
 /// let query = "select 1; this statement is not sql; select 2;";
 /// let result = pg_query::split_with_parser(query);
@@ -207,9 +207,9 @@ pub fn split_with_parser(query: &str) -> Result<Vec<&str>> {
 }
 
 /// Scan a sql query into a its component of tokens.
-/// 
+///
 /// # Example
-/// 
+///
 /// ```rust
 /// use pg_query::protobuf::*;
 /// let sql = "SELECT update AS left /* comment */ FROM between";
@@ -242,7 +242,6 @@ pub fn scan(sql: &str) -> Result<protobuf::ScanResult> {
     unsafe { pg_query_free_scan_result(result) };
     scan_result
 }
-
 
 /// Split a potentially-malformed query into separate statements. Note that
 /// invalid tokens will be skipped

--- a/src/query.rs
+++ b/src/query.rs
@@ -3,7 +3,7 @@ use std::os::raw::{c_char, c_uint};
 
 use prost::Message;
 
-// use crate::*;
+// use crate::scan_result::ScanResult;
 use crate::bindings::*;
 use crate::error::*;
 use crate::parse_result::ParseResult;
@@ -165,4 +165,77 @@ pub fn parse_plpgsql(stmt: &str) -> Result<serde_json::Value> {
     };
     unsafe { pg_query_free_plpgsql_parse_result(result) };
     structure
+}
+
+/// Split a well-formed query into separate statements.
+/// ```rust
+/// let query = r#"select /*;*/ 1; select "2;", (select 3);"#;
+/// let statements = pg_query::split_with_parser(query).unwrap();
+/// assert_eq!(statements, vec!["select /*;*/ 1", r#" select "2;", (select 3)"#]);
+/// ```
+///
+/// However, `split_with_parser` will fail on malformed statements
+/// ```rust
+/// let query = "select 1; this statement is not sql; select 2;";
+/// let result = pg_query::split_with_parser(query);
+/// let err = r#"syntax error at or near "this""#;
+/// assert_eq!(result, Err(pg_query::Error::Split(err.to_string())));
+/// ```
+pub fn split_with_parser(query: &str) -> Result<Vec<&str>> {
+    let input = CString::new(query)?;
+    let result = unsafe { pg_query_split_with_parser(input.as_ptr()) };
+    let split_result = if !result.error.is_null() {
+        let message = unsafe { CStr::from_ptr((*result.error).message) }.to_string_lossy().to_string();
+        Err(Error::Split(message))
+    } else {
+        let n_stmts = result.n_stmts as usize;
+        let mut statements = Vec::with_capacity(n_stmts);
+        for offset in 0..n_stmts {
+            let split_stmt = unsafe { *result.stmts.add(offset).read() };
+            let start = split_stmt.stmt_location as usize;
+            let end = start + split_stmt.stmt_len as usize;
+            statements.push(&query[start..end]);
+            // not sure the start..end slice'll hold up for non-utf8 charsets
+        }
+        Ok(statements)
+    };
+    unsafe { pg_query_free_split_result(result) };
+    split_result
+}
+
+/// Split a potentially-malformed query into separate statements.
+/// ```rust
+/// let query = r#"select /*;*/ 1; asdf; select "2;", (select 3);"#;
+/// let statements = pg_query::split_with_scanner(query).unwrap();
+/// assert_eq!(statements, vec![
+///     "select /*;*/ 1",
+///     // missing: " asdf", not scanned?
+///     r#" select "2;", (select 3)"#,
+/// ]);
+/// ```
+pub fn split_with_scanner(query: &str) -> Result<Vec<&str>> {
+    let input = CString::new(query)?;
+    let result = unsafe { pg_query_split_with_scanner(input.as_ptr()) };
+    let split_result = if !result.error.is_null() {
+        let message = unsafe { CStr::from_ptr((*result.error).message) }.to_string_lossy().to_string();
+        Err(Error::Split(message))
+    } else {
+        // don't use result.stderr_buffer since it appears unused unless
+        // libpg_query is compiled with DEBUG defined.
+        let n_stmts = result.n_stmts as usize;
+        let mut start: usize;
+        let mut end: usize;
+        let mut statements = Vec::with_capacity(n_stmts);
+        for offset in 0..n_stmts {
+            let split_stmt = unsafe { *result.stmts.add(offset).read() };
+            start = split_stmt.stmt_location as usize;
+            // TODO: consider comparing the new value of start to the old value
+            // of end to see if any region larger than a statement-separator got skipped
+            end = start + split_stmt.stmt_len as usize;
+            statements.push(&query[start..end]);
+        }
+        Ok(statements)
+    };
+    unsafe { pg_query_free_split_result(result) };
+    split_result
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -168,6 +168,9 @@ pub fn parse_plpgsql(stmt: &str) -> Result<serde_json::Value> {
 }
 
 /// Split a well-formed query into separate statements.
+/// 
+/// # Example
+/// 
 /// ```rust
 /// let query = r#"select /*;*/ 1; select "2;", (select 3);"#;
 /// let statements = pg_query::split_with_parser(query).unwrap();
@@ -175,6 +178,7 @@ pub fn parse_plpgsql(stmt: &str) -> Result<serde_json::Value> {
 /// ```
 ///
 /// However, `split_with_parser` will fail on malformed statements
+/// 
 /// ```rust
 /// let query = "select 1; this statement is not sql; select 2;";
 /// let result = pg_query::split_with_parser(query);
@@ -203,7 +207,10 @@ pub fn split_with_parser(query: &str) -> Result<Vec<&str>> {
     split_result
 }
 
-///
+/// Scan a sql query into a its component of tokens.
+/// 
+/// # Example
+/// 
 /// ```rust
 /// use pg_query::protobuf::*;
 /// let sql = "SELECT update AS left /* comment */ FROM between";
@@ -238,13 +245,14 @@ pub fn scan(sql: &str) -> Result<protobuf::ScanResult> {
 }
 
 
-/// Split a potentially-malformed query into separate statements.
+/// Split a potentially-malformed query into separate statements. Note that
+/// invalid tokens will be skipped
 /// ```rust
 /// let query = r#"select /*;*/ 1; asdf; select "2;", (select 3); asdf"#;
 /// let statements = pg_query::split_with_scanner(query).unwrap();
 /// assert_eq!(statements, vec![
 ///     "select /*;*/ 1",
-///     // missing: " asdf", not scanned?
+///     // skipped " asdf" since it was an invalid token
 ///     r#" select "2;", (select 3)"#,
 /// ]);
 /// ```


### PR DESCRIPTION
I'm noticing some weirdness in the split_with_scanner example. Malformed tokens seem to be getting dropped:
```rs
assert_eq!(
    pg_query::split_with_scanner("select 1; asdf; select 3;").unwrap(),
    vec!["select 1", "asdf", "select 3"],
); // fails: actually produces ["select 1", "select 3"]
```
Is this expected?

Resolves #5.