### PR TITLE
Fix memory leaks in fingerprint and normalize

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,12 +10,15 @@ name: Continuous integration
 
 jobs:
   ci:
+    env:
+      RUSTFLAGS: ${{ matrix.rust == 'nightly' && '-Z sanitizer=leak' || '' }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         rust:
           - stable
-          - beta
+          - nightly
 
     steps:
       - uses: actions/checkout@v2

--- a/src/query.rs
+++ b/src/query.rs
@@ -97,10 +97,10 @@ pub fn deparse(protobuf: &protobuf::ParseResult) -> Result<String> {
 /// ```
 pub fn normalize(statement: &str) -> Result<String> {
     let input = CString::new(statement).unwrap();
-    let result = unsafe { pg_query_normalize(input.as_ptr() as *const c_char) };
+    let result = unsafe { pg_query_normalize(input.as_ptr()) };
     let normalized_query = if !result.error.is_null() {
         let message = unsafe { CStr::from_ptr((*result.error).message) }.to_string_lossy().to_string();
-        return Err(Error::Parse(message));
+        Err(Error::Parse(message))
     } else {
         let n = unsafe { CStr::from_ptr(result.normalized_query) };
         Ok(n.to_string_lossy().to_string())


### PR DESCRIPTION
- `fingerprint` is affected by https://github.com/pganalyze/libpg_query/pull/141
- when an error occurs, `normalize` is returning early before `pg_query_free_normalize_result` was called