### PR TITLE
Fix `LeakSanitizer` segfault

### DIFF
--- a/tests/parallel_tests.rs
+++ b/tests/parallel_tests.rs
@@ -3,7 +3,7 @@ fn it_does_not_error_when_run_in_parallel() {
     use easy_parallel::Parallel;
 
     let mut queries = vec![];
-    for _ in 0..10000 {
+    for _ in 0..100 {
         queries.push(
             r#"
             SELECT * FROM "t0"
@@ -28,10 +28,12 @@ fn it_does_not_error_when_run_in_parallel() {
 
     Parallel::new()
         .each(queries, |query| {
-            let result = pg_query::parse(query).unwrap();
-            pg_query::fingerprint(query).unwrap();
-            result.truncate(10).unwrap();
-            pg_query::normalize(query).unwrap();
+            for _ in 0..100 {
+                let result = pg_query::parse(query).unwrap();
+                pg_query::fingerprint(query).unwrap();
+                result.truncate(10).unwrap();
+                pg_query::normalize(query).unwrap();
+            }
         })
         .run();
 }


### PR DESCRIPTION
It looks like spawning 10,000 threads with our particular workload causes `LeakSanitizer` to segfault on [`GetThreadLocked`] in an array access. This is likely a bug in `LeakSanitizer`; it is segfaulting on an array access to an internal `threads_` datastructure, indexed by thread ID.

Reducing the total thread count in `parallel_tests` seems to solve the issue. To ensure we still test contention, each thread now does more repeated work.

[`GetThreadLocked`]: https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/sanitizer_common/sanitizer_thread_registry.h#L104