### PR TITLE
Fix undefined behavior in `CStr` creation

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -68,9 +68,8 @@ pub fn parse(statement: &str) -> Result<ParseResult> {
 pub fn deparse(protobuf: &protobuf::ParseResult) -> Result<String> {
     let buffer = protobuf.encode_to_vec();
     let len = buffer.len() as size_t;
-    let input = unsafe { CStr::from_bytes_with_nul_unchecked(&buffer) };
-    let data = input.as_ptr() as *mut c_char;
-    let protobuf = PgQueryProtobuf { data: data, len: len };
+    let data = buffer.as_ptr() as *const c_char as *mut c_char;
+    let protobuf = PgQueryProtobuf { data, len };
     let result = unsafe { pg_query_deparse_protobuf(protobuf) };
 
     let deparse_result = if !result.error.is_null() {


### PR DESCRIPTION
We previously called `from_bytes_with_nul_unchecked` on a buffer that was generated by `prost`, and not null-terminated. This is undefined behavior; however it coincidentally continued to work as we didn't do anything with this `CStr` except get a pointer to the first byte.

Because we didn't do much with this `CStr`, we can completely remove the undefined behavior and fix the problem by just retrieving a pointer to the buffer start directly.

This was originally caught by running tests through `AddressSanitizer`.