### PR TITLE
Update to libpg_query 4.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## Unreleased
+## 0.8.0    2023-07-25
 
-* Upgrade to PostgreSQL 15.1 via libpg_query 4.2.0
+* Upgrade to libpg_query 4.2.2 (Postgres 13 -> 15)
 * Improve `ParseResult::tables()` to find tables in `cast` expressions
 
 ## 0.7.0     2022-07-19


### PR DESCRIPTION
Closes #20

After this is merged I'll release 0.8.0 to crates.io