### PR TITLE
Bump version to 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.8.1    2023-08-07
 
 * Upgrade to `libpg_query` 4.2.3
   - Fix builds when compiling with `glibc >=  2.38` [#203](https://github.com/pganalyze/libpg_query/pull/203)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pg_query"
 description = "PostgreSQL parser that uses the actual PostgreSQL server source to parse SQL queries and return the internal PostgreSQL parse tree."
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 documentation = "https://docs.rs/pg_query/"
 build = "build.rs"


### PR DESCRIPTION
After this is merged I can release 0.8.1 to crates.io.