### PR TITLE
Fix release builds for musl targets

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -39,6 +39,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     make.env_remove("PROFILE").arg("-C").arg(&out_dir).arg("build");
 
+    if env::var("TARGET").unwrap().ends_with("-musl") {
+        make.env("CC", "musl-gcc");
+    }
+
     if env::var("PROFILE").unwrap() == "debug" {
         make.arg("DEBUG=1");
     }


### PR DESCRIPTION
The `libpg_query.a` static archive fails to link during a release build for musl targets with errors like: "undefined reference to `_longjmp_chk'".

This appears to be caused by the fact that the static archive is compiled with the default toolchain, and so has references to symbols provided by glibc (but not musl libc).

This change switches to use the `musl-gcc` wrapper as `CC` when the target triple ends with `-musl`.