### PR TITLE
Windows support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/data/* binary

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -34,39 +34,51 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: ${{ runner.os }}-${{ matrix.backend }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ matrix.os }}-${{ matrix.rust }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+
+      - name: Install rustup if needed
+        run: |
+          if ! command -v rustup &>/dev/null; then
+            curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused --location --silent --show-error --fail "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
+          fi
+        if: runner.os != 'Windows'
+        shell: bash
 
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
+        run: rustup toolchain install ${{ matrix.rust }} --profile minimal --no-self-update
+        shell: bash
+
+      - name: Default to nightly if requested
+        run: rustup default nightly
+        if: matrix.rust == 'nightly'
 
       - name: Build pg_query
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
+        run: cargo build
 
       - name: Run tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+        run: cargo test
 
   check_style:
     name: Check file formatting and style
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          components: clippy, rustfmt
-          override: true
+      - name: Install rustup if needed
+        run: |
+          if ! command -v rustup &>/dev/null; then
+            curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused --location --silent --show-error --fail "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
+          fi
+        if: runner.os != 'Windows'
+        shell: bash
+
+      - name: Install toolchain
+        run: rustup toolchain install stable --component clippy --component rustfmt --profile minimal --no-self-update
+        shell: bash
 
       - name: Cache cargo registry
         uses: actions/cache@v2
@@ -77,12 +89,7 @@ jobs:
           key: clippy-cargo-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Check file formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Run clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
+        run: cargo clippy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,14 +11,17 @@ name: Continuous integration
 jobs:
   ci:
     env:
-      RUSTFLAGS: ${{ matrix.rust == 'nightly' && '-Z sanitizer=leak' || '' }}
-    runs-on: ubuntu-latest
+      RUSTFLAGS: ${{ matrix.rust == 'nightly' && matrix.os == 'ubuntu-latest' && '-Z sanitizer=leak' || '' }}
     strategy:
       fail-fast: false
       matrix:
         rust:
           - stable
           - nightly
+        os:
+          - ubuntu-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,11 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
+        include:
+          - rust: stable-x86_64-pc-windows-gnu
+            os: windows-latest
+          - rust: stable-i686-pc-windows-msvc
+            os: windows-latest
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,9 +393,11 @@ name = "pg_query"
 version = "5.0.0"
 dependencies = [
  "bindgen",
+ "cc",
  "clippy",
  "easy-parallel",
  "fs_extra",
+ "glob",
  "itertools",
  "pretty_assertions",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ bindgen = "0.66.1"
 clippy = { version = "0.0.302", optional = true }
 prost-build = "0.10.4"
 fs_extra = "1.2.0"
+cc = "1.0.83"
+glob = "0.3.1"
 
 [dev-dependencies]
 easy-parallel = "3.2.0"


### PR DESCRIPTION
Note that this also removes our use of the `Makefile` in `build.rs`, and instead uses the `cc` crate to build libpg_query directly. This matches what we do in other libraries (pg_query in Ruby, pg_query_go).

Depends on https://github.com/pganalyze/libpg_query/pull/233

Fixes #34