### PR TITLE
Remove unused imports

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -5,7 +5,6 @@ use fs_extra::dir::CopyOptions;
 use glob::glob;
 use std::env;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
 
 static SOURCE_DIRECTORY: &str = "libpg_query";
 static LIBRARY_NAME: &str = "pg_query";

--- a/tests/parse_plpgsql_tests.rs
+++ b/tests/parse_plpgsql_tests.rs
@@ -1,6 +1,5 @@
 #[macro_use]
 mod support;
-use support::*;
 
 #[test]
 fn it_can_parse_a_simple_function() {


### PR DESCRIPTION
We were receiving warnings about these, and it doesn't appear they are needed.