### PR TITLE
Release 5.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .idea/
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 5.1.1    2024-10-17
+## 5.1.1    2024-10-30
 
 * Make `ParseResult` struct public and implement `Debug`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.1.1    2024-10-17
+
+* Make `ParseResult` struct public and implement `Debug`
+
 ## 5.1.0    2024-01-09
 
 * Update to libpg_query 16-5.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "pg_query"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pg_query"
 description = "PostgreSQL parser that uses the actual PostgreSQL server source to parse SQL queries and return the internal PostgreSQL parse tree."
-version = "5.1.0"
+version = "5.1.1"
 edition = "2021"
 documentation = "https://docs.rs/pg_query/"
 build = "build.rs"

--- a/src/parse_result.rs
+++ b/src/parse_result.rs
@@ -51,6 +51,8 @@ impl protobuf::ParseResult {
     }
 }
 
+/// Result from calling [parse]
+#[derive(Debug)]
 pub struct ParseResult {
     pub protobuf: protobuf::ParseResult,
     pub warnings: Vec<String>,
@@ -215,7 +217,7 @@ impl ParseResult {
             .collect()
     }
 
-    /// Returns any references to tables in the query
+    /// Returns all function references
     pub fn functions(&self) -> Vec<String> {
         let mut functions = HashSet::new();
         self.functions.iter().for_each(|(f, _c)| {
@@ -246,6 +248,7 @@ impl ParseResult {
             .collect()
     }
 
+    /// Converts the parsed query back into a SQL string
     pub fn deparse(&self) -> Result<String> {
         crate::deparse(&self.protobuf)
     }
@@ -263,6 +266,7 @@ impl ParseResult {
         crate::truncate(&self.protobuf, max_length)
     }
 
+    /// Returns all statement types in the query
     pub fn statement_types(&self) -> Vec<&str> {
         self.protobuf
             .stmts


### PR DESCRIPTION
`ParseResult` was made public in #43, and in passing this PR also implements `Debug` since that was requested in #45