### PR TITLE
Include serialize feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,6 @@ glob = "0.3.1"
 easy-parallel = "3.2.0"
 pretty_assertions = "1.4.0"
 regex = "1.6.0"
+
+[features]
+serialize = []

--- a/build.rs
+++ b/build.rs
@@ -65,7 +65,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .write_to_file(out_dir.join("bindings.rs"))?;
 
     // Generate the protobuf definition
-    prost_build::compile_protos(&[&out_protobuf_path.join(LIBRARY_NAME).with_extension("proto")], &[&out_protobuf_path])?;
+    let mut prost_build = prost_build::Config::new();
+    if env::var("CARGO_FEATURE_SERIALIZE").is_ok() {
+        prost_build.type_attribute(".", "#[derive(serde::Serialize)]");
+    }
+
+    prost_build.compile_protos(&[&out_protobuf_path.join(LIBRARY_NAME).with_extension("proto")], &[&out_protobuf_path])?;
 
     Ok(())
 }

--- a/src/node_enum.rs
+++ b/src/node_enum.rs
@@ -1,8 +1,11 @@
 use crate::*;
 
 pub use protobuf::node::Node as NodeEnum;
+use serde::Serialize;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[cfg(feature = "serialize")]
+#[derive(Serialize)]
 pub enum Context {
     None,
     Select,


### PR DESCRIPTION
For inspecting statements and storing them (in PostgreSQL as json for example) it is sometimes useful to serialize the parsed query.

This feature flag allows this to happen.