### PR TITLE
Expose tables and functions directly (ParseResult)

### DIFF
--- a/src/parse_result.rs
+++ b/src/parse_result.rs
@@ -56,10 +56,10 @@ impl protobuf::ParseResult {
 pub struct ParseResult {
     pub protobuf: protobuf::ParseResult,
     pub warnings: Vec<String>,
-    tables: Vec<(String, Context)>,
+    pub tables: Vec<(String, Context)>,
     pub aliases: HashMap<String, String>,
     pub cte_names: Vec<String>,
-    functions: Vec<(String, Context)>,
+    pub functions: Vec<(String, Context)>,
     pub filter_columns: Vec<(Option<String>, String)>,
 }
 


### PR DESCRIPTION
For some tasks, I'm looking to iterate over the tables (or functions), and I would ideally also know the `Context` in which they have been used.

I can get the tables that have a certain context, for example using https://docs.rs/pg_query/latest/pg_query/struct.ParseResult.html#method.dml_tables, however for my purposes I'd rather loop over `tables` directly.

Alternatively, something like this could also work, depending on the appetite to not expose internal fields?

```rust
    /// Returns all referenced tables (with context) in the query
    pub fn tables_and_contexts(&self) -> Vec<(String, Context)> {
        self.tables.clone()
    }
```