### PR TITLE
Shrink packaged crate size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ include = [
     "Makefile", "pg_query.h",
     "libpg_query/{src,vendor}/**/*.{c,h}",
     "libpg_query/protobuf/{pg_query.pb-c.*,pg_query.proto}",
-    "!libpg_query/src/postgres/*.c",
 ]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,18 @@ name = "pg_query"
 description = "PostgreSQL parser that uses the actual PostgreSQL server source to parse SQL queries and return the internal PostgreSQL parse tree."
 version = "6.0.0"
 edition = "2021"
-documentation = "https://docs.rs/pg_query/"
-build = "build.rs"
+documentation = "https://docs.rs/pg_query"
 license = "MIT"
-readme = "./README.md"
 repository = "https://github.com/pganalyze/pg_query.rs"
+include = [
+    # pg_query.rs
+    "README.md", "build.rs", "src/**/*.rs",
+    # libpg_query
+    "Makefile", "pg_query.h",
+    "libpg_query/{src,vendor}/**/*.{c,h}",
+    "libpg_query/protobuf/{pg_query.pb-c.*,pg_query.proto}",
+    "!libpg_query/src/postgres/*.c",
+]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
crates.io reports the crate size as being fairly large: 4.26 MB (compressed). This PR improves that to 2.4 MB by excluding unneeded files from the cargo package.

To see the list of files included in the package:
```sh
cargo package --allow-dirty --list
```

To generate a package, and in the output see the resulting package size:
```sh
cargo package --allow-dirty
```

<details><summary>For reference, here's the current list of files. There are probably additional Postgres source files that can be excluded.</summary>

```
.cargo_vcs_info.json
Cargo.lock
Cargo.toml
Cargo.toml.orig
README.md
build.rs
libpg_query/Makefile
libpg_query/README.md
libpg_query/pg_query.h
libpg_query/protobuf/pg_query.pb-c.c
libpg_query/protobuf/pg_query.pb-c.h
libpg_query/protobuf/pg_query.pb-c.o
libpg_query/protobuf/pg_query.proto
libpg_query/src/include/pg_query_enum_defs.c
libpg_query/src/include/pg_query_fingerprint_conds.c
libpg_query/src/include/pg_query_fingerprint_defs.c
libpg_query/src/include/pg_query_json_helper.c
libpg_query/src/include/pg_query_outfuncs_conds.c
libpg_query/src/include/pg_query_outfuncs_defs.c
libpg_query/src/include/pg_query_readfuncs_conds.c
libpg_query/src/include/pg_query_readfuncs_defs.c
libpg_query/src/pg_query.c
libpg_query/src/pg_query_deparse.c
libpg_query/src/pg_query_fingerprint.c
libpg_query/src/pg_query_fingerprint.h
libpg_query/src/pg_query_internal.h
libpg_query/src/pg_query_json_plpgsql.c
libpg_query/src/pg_query_json_plpgsql.h
libpg_query/src/pg_query_normalize.c
libpg_query/src/pg_query_outfuncs.h
libpg_query/src/pg_query_outfuncs_json.c
libpg_query/src/pg_query_outfuncs_protobuf.c
libpg_query/src/pg_query_parse.c
libpg_query/src/pg_query_parse_plpgsql.c
libpg_query/src/pg_query_readfuncs.h
libpg_query/src/pg_query_readfuncs_protobuf.c
libpg_query/src/pg_query_scan.c
libpg_query/src/pg_query_split.c
libpg_query/src/postgres/include/access/amapi.h
libpg_query/src/postgres/include/access/attmap.h
libpg_query/src/postgres/include/access/attnum.h
libpg_query/src/postgres/include/access/brin_internal.h
libpg_query/src/postgres/include/access/brin_tuple.h
libpg_query/src/postgres/include/access/clog.h
libpg_query/src/postgres/include/access/commit_ts.h
libpg_query/src/postgres/include/access/detoast.h
libpg_query/src/postgres/include/access/genam.h
libpg_query/src/postgres/include/access/gin.h
libpg_query/src/postgres/include/access/htup.h
libpg_query/src/postgres/include/access/htup_details.h
libpg_query/src/postgres/include/access/itup.h
libpg_query/src/postgres/include/access/parallel.h
libpg_query/src/postgres/include/access/printtup.h
libpg_query/src/postgres/include/access/relation.h
libpg_query/src/postgres/include/access/relscan.h
libpg_query/src/postgres/include/access/rmgr.h
libpg_query/src/postgres/include/access/rmgrlist.h
libpg_query/src/postgres/include/access/sdir.h
libpg_query/src/postgres/include/access/skey.h
libpg_query/src/postgres/include/access/slru.h
libpg_query/src/postgres/include/access/stratnum.h
libpg_query/src/postgres/include/access/sysattr.h
libpg_query/src/postgres/include/access/table.h
libpg_query/src/postgres/include/access/tableam.h
libpg_query/src/postgres/include/access/tidstore.h
libpg_query/src/postgres/include/access/toast_compression.h
libpg_query/src/postgres/include/access/transam.h
libpg_query/src/postgres/include/access/tsmapi.h
libpg_query/src/postgres/include/access/tupconvert.h
libpg_query/src/postgres/include/access/tupdesc.h
libpg_query/src/postgres/include/access/tupmacs.h
libpg_query/src/postgres/include/access/twophase.h
libpg_query/src/postgres/include/access/xact.h
libpg_query/src/postgres/include/access/xlog.h
libpg_query/src/postgres/include/access/xlog_internal.h
libpg_query/src/postgres/include/access/xlogbackup.h
libpg_query/src/postgres/include/access/xlogdefs.h
libpg_query/src/postgres/include/access/xlogprefetcher.h
libpg_query/src/postgres/include/access/xlogreader.h
libpg_query/src/postgres/include/access/xlogrecord.h
libpg_query/src/postgres/include/access/xlogrecovery.h
libpg_query/src/postgres/include/archive/archive_module.h
libpg_query/src/postgres/include/c.h
libpg_query/src/postgres/include/catalog/catalog.h
libpg_query/src/postgres/include/catalog/catversion.h
libpg_query/src/postgres/include/catalog/dependency.h
libpg_query/src/postgres/include/catalog/genbki.h
libpg_query/src/postgres/include/catalog/index.h
libpg_query/src/postgres/include/catalog/indexing.h
libpg_query/src/postgres/include/catalog/namespace.h
libpg_query/src/postgres/include/catalog/objectaccess.h
libpg_query/src/postgres/include/catalog/objectaddress.h
libpg_query/src/postgres/include/catalog/pg_aggregate.h
libpg_query/src/postgres/include/catalog/pg_aggregate_d.h
libpg_query/src/postgres/include/catalog/pg_am.h
libpg_query/src/postgres/include/catalog/pg_am_d.h
libpg_query/src/postgres/include/catalog/pg_attribute.h
libpg_query/src/postgres/include/catalog/pg_attribute_d.h
libpg_query/src/postgres/include/catalog/pg_authid.h
libpg_query/src/postgres/include/catalog/pg_authid_d.h
libpg_query/src/postgres/include/catalog/pg_class.h
libpg_query/src/postgres/include/catalog/pg_class_d.h
libpg_query/src/postgres/include/catalog/pg_collation.h
libpg_query/src/postgres/include/catalog/pg_collation_d.h
libpg_query/src/postgres/include/catalog/pg_constraint.h
libpg_query/src/postgres/include/catalog/pg_constraint_d.h
libpg_query/src/postgres/include/catalog/pg_control.h
libpg_query/src/postgres/include/catalog/pg_conversion.h
libpg_query/src/postgres/include/catalog/pg_conversion_d.h
libpg_query/src/postgres/include/catalog/pg_database.h
libpg_query/src/postgres/include/catalog/pg_database_d.h
libpg_query/src/postgres/include/catalog/pg_depend.h
libpg_query/src/postgres/include/catalog/pg_depend_d.h
libpg_query/src/postgres/include/catalog/pg_event_trigger.h
libpg_query/src/postgres/include/catalog/pg_event_trigger_d.h
libpg_query/src/postgres/include/catalog/pg_index.h
libpg_query/src/postgres/include/catalog/pg_index_d.h
libpg_query/src/postgres/include/catalog/pg_language.h
libpg_query/src/postgres/include/catalog/pg_language_d.h
libpg_query/src/postgres/include/catalog/pg_namespace.h
libpg_query/src/postgres/include/catalog/pg_namespace_d.h
libpg_query/src/postgres/include/catalog/pg_opclass.h
libpg_query/src/postgres/include/catalog/pg_opclass_d.h
libpg_query/src/postgres/include/catalog/pg_operator.h
libpg_query/src/postgres/include/catalog/pg_operator_d.h
libpg_query/src/postgres/include/catalog/pg_opfamily.h
libpg_query/src/postgres/include/catalog/pg_opfamily_d.h
libpg_query/src/postgres/include/catalog/pg_partitioned_table.h
libpg_query/src/postgres/include/catalog/pg_partitioned_table_d.h
libpg_query/src/postgres/include/catalog/pg_proc.h
libpg_query/src/postgres/include/catalog/pg_proc_d.h
libpg_query/src/postgres/include/catalog/pg_publication.h
libpg_query/src/postgres/include/catalog/pg_publication_d.h
libpg_query/src/postgres/include/catalog/pg_replication_origin.h
libpg_query/src/postgres/include/catalog/pg_replication_origin_d.h
libpg_query/src/postgres/include/catalog/pg_statistic.h
libpg_query/src/postgres/include/catalog/pg_statistic_d.h
libpg_query/src/postgres/include/catalog/pg_statistic_ext.h
libpg_query/src/postgres/include/catalog/pg_statistic_ext_d.h
libpg_query/src/postgres/include/catalog/pg_transform.h
libpg_query/src/postgres/include/catalog/pg_transform_d.h
libpg_query/src/postgres/include/catalog/pg_trigger.h
libpg_query/src/postgres/include/catalog/pg_trigger_d.h
libpg_query/src/postgres/include/catalog/pg_ts_config.h
libpg_query/src/postgres/include/catalog/pg_ts_config_d.h
libpg_query/src/postgres/include/catalog/pg_ts_dict.h
libpg_query/src/postgres/include/catalog/pg_ts_dict_d.h
libpg_query/src/postgres/include/catalog/pg_ts_parser.h
libpg_query/src/postgres/include/catalog/pg_ts_parser_d.h
libpg_query/src/postgres/include/catalog/pg_ts_template.h
libpg_query/src/postgres/include/catalog/pg_ts_template_d.h
libpg_query/src/postgres/include/catalog/pg_type.h
libpg_query/src/postgres/include/catalog/pg_type_d.h
libpg_query/src/postgres/include/catalog/storage.h
libpg_query/src/postgres/include/catalog/syscache_ids.h
libpg_query/src/postgres/include/commands/async.h
libpg_query/src/postgres/include/commands/dbcommands.h
libpg_query/src/postgres/include/commands/defrem.h
libpg_query/src/postgres/include/commands/event_trigger.h
libpg_query/src/postgres/include/commands/explain.h
libpg_query/src/postgres/include/commands/prepare.h
libpg_query/src/postgres/include/commands/tablespace.h
libpg_query/src/postgres/include/commands/trigger.h
libpg_query/src/postgres/include/commands/user.h
libpg_query/src/postgres/include/commands/vacuum.h
libpg_query/src/postgres/include/common/cryptohash.h
libpg_query/src/postgres/include/common/file_perm.h
libpg_query/src/postgres/include/common/file_utils.h
libpg_query/src/postgres/include/common/hashfn.h
libpg_query/src/postgres/include/common/hashfn_unstable.h
libpg_query/src/postgres/include/common/int.h
libpg_query/src/postgres/include/common/keywords.h
libpg_query/src/postgres/include/common/kwlookup.h
libpg_query/src/postgres/include/common/pg_prng.h
libpg_query/src/postgres/include/common/relpath.h
libpg_query/src/postgres/include/common/scram-common.h
libpg_query/src/postgres/include/common/sha2.h
libpg_query/src/postgres/include/common/string.h
libpg_query/src/postgres/include/common/unicode_east_asian_fw_table.h
libpg_query/src/postgres/include/common/unicode_nonspacing_table.h
libpg_query/src/postgres/include/copyfuncs.funcs.c
libpg_query/src/postgres/include/copyfuncs.switch.c
libpg_query/src/postgres/include/datatype/timestamp.h
libpg_query/src/postgres/include/equalfuncs.funcs.c
libpg_query/src/postgres/include/equalfuncs.switch.c
libpg_query/src/postgres/include/executor/execdesc.h
libpg_query/src/postgres/include/executor/executor.h
libpg_query/src/postgres/include/executor/functions.h
libpg_query/src/postgres/include/executor/instrument.h
libpg_query/src/postgres/include/executor/spi.h
libpg_query/src/postgres/include/executor/tablefunc.h
libpg_query/src/postgres/include/executor/tuptable.h
libpg_query/src/postgres/include/fmgr.h
libpg_query/src/postgres/include/foreign/fdwapi.h
libpg_query/src/postgres/include/funcapi.h
libpg_query/src/postgres/include/gram.h
libpg_query/src/postgres/include/gramparse.h
libpg_query/src/postgres/include/jit/jit.h
libpg_query/src/postgres/include/kwlist_d.h
libpg_query/src/postgres/include/lib/dshash.h
libpg_query/src/postgres/include/lib/ilist.h
libpg_query/src/postgres/include/lib/pairingheap.h
libpg_query/src/postgres/include/lib/simplehash.h
libpg_query/src/postgres/include/lib/sort_template.h
libpg_query/src/postgres/include/lib/stringinfo.h
libpg_query/src/postgres/include/libpq/auth.h
libpg_query/src/postgres/include/libpq/crypt.h
libpg_query/src/postgres/include/libpq/hba.h
libpg_query/src/postgres/include/libpq/libpq-be.h
libpg_query/src/postgres/include/libpq/libpq.h
libpg_query/src/postgres/include/libpq/pqcomm.h
libpg_query/src/postgres/include/libpq/pqformat.h
libpg_query/src/postgres/include/libpq/pqsignal.h
libpg_query/src/postgres/include/libpq/protocol.h
libpg_query/src/postgres/include/libpq/sasl.h
libpg_query/src/postgres/include/libpq/scram.h
libpg_query/src/postgres/include/mb/pg_wchar.h
libpg_query/src/postgres/include/mb/stringinfo_mb.h
libpg_query/src/postgres/include/miscadmin.h
libpg_query/src/postgres/include/nodes/bitmapset.h
libpg_query/src/postgres/include/nodes/execnodes.h
libpg_query/src/postgres/include/nodes/extensible.h
libpg_query/src/postgres/include/nodes/lockoptions.h
libpg_query/src/postgres/include/nodes/makefuncs.h
libpg_query/src/postgres/include/nodes/memnodes.h
libpg_query/src/postgres/include/nodes/miscnodes.h
libpg_query/src/postgres/include/nodes/nodeFuncs.h
libpg_query/src/postgres/include/nodes/nodes.h
libpg_query/src/postgres/include/nodes/nodetags.h
libpg_query/src/postgres/include/nodes/params.h
libpg_query/src/postgres/include/nodes/parsenodes.h
libpg_query/src/postgres/include/nodes/pathnodes.h
libpg_query/src/postgres/include/nodes/pg_list.h
libpg_query/src/postgres/include/nodes/plannodes.h
libpg_query/src/postgres/include/nodes/primnodes.h
libpg_query/src/postgres/include/nodes/print.h
libpg_query/src/postgres/include/nodes/queryjumble.h
libpg_query/src/postgres/include/nodes/replnodes.h
libpg_query/src/postgres/include/nodes/supportnodes.h
libpg_query/src/postgres/include/nodes/tidbitmap.h
libpg_query/src/postgres/include/nodes/value.h
libpg_query/src/postgres/include/optimizer/cost.h
libpg_query/src/postgres/include/optimizer/geqo.h
libpg_query/src/postgres/include/optimizer/geqo_gene.h
libpg_query/src/postgres/include/optimizer/optimizer.h
libpg_query/src/postgres/include/optimizer/paths.h
libpg_query/src/postgres/include/optimizer/planmain.h
libpg_query/src/postgres/include/parser/analyze.h
libpg_query/src/postgres/include/parser/kwlist.h
libpg_query/src/postgres/include/parser/parse_agg.h
libpg_query/src/postgres/include/parser/parse_coerce.h
libpg_query/src/postgres/include/parser/parse_expr.h
libpg_query/src/postgres/include/parser/parse_func.h
libpg_query/src/postgres/include/parser/parse_node.h
libpg_query/src/postgres/include/parser/parse_oper.h
libpg_query/src/postgres/include/parser/parse_relation.h
libpg_query/src/postgres/include/parser/parse_type.h
libpg_query/src/postgres/include/parser/parser.h
libpg_query/src/postgres/include/parser/parsetree.h
libpg_query/src/postgres/include/parser/scanner.h
libpg_query/src/postgres/include/parser/scansup.h
libpg_query/src/postgres/include/partitioning/partdefs.h
libpg_query/src/postgres/include/pg_config.h
libpg_query/src/postgres/include/pg_config_ext.h
libpg_query/src/postgres/include/pg_config_manual.h
libpg_query/src/postgres/include/pg_config_os.h
libpg_query/src/postgres/include/pg_getopt.h
libpg_query/src/postgres/include/pg_trace.h
libpg_query/src/postgres/include/pgstat.h
libpg_query/src/postgres/include/pgtime.h
libpg_query/src/postgres/include/pl_gram.h
libpg_query/src/postgres/include/pl_reserved_kwlist.h
libpg_query/src/postgres/include/pl_reserved_kwlist_d.h
libpg_query/src/postgres/include/pl_unreserved_kwlist.h
libpg_query/src/postgres/include/pl_unreserved_kwlist_d.h
libpg_query/src/postgres/include/plerrcodes.h
libpg_query/src/postgres/include/plpgsql.h
libpg_query/src/postgres/include/port/atomics/arch-arm.h
libpg_query/src/postgres/include/port/atomics/arch-hppa.h
libpg_query/src/postgres/include/port/atomics/arch-ppc.h
libpg_query/src/postgres/include/port/atomics/arch-x86.h
libpg_query/src/postgres/include/port/atomics/fallback.h
libpg_query/src/postgres/include/port/atomics/generic-gcc.h
libpg_query/src/postgres/include/port/atomics/generic-msvc.h
libpg_query/src/postgres/include/port/atomics/generic-sunpro.h
libpg_query/src/postgres/include/port/atomics/generic.h
libpg_query/src/postgres/include/port/atomics.h
libpg_query/src/postgres/include/port/pg_bitutils.h
libpg_query/src/postgres/include/port/pg_bswap.h
libpg_query/src/postgres/include/port/pg_crc32c.h
libpg_query/src/postgres/include/port/pg_iovec.h
libpg_query/src/postgres/include/port/simd.h
libpg_query/src/postgres/include/port/win32/arpa/inet.h
libpg_query/src/postgres/include/port/win32/dlfcn.h
libpg_query/src/postgres/include/port/win32/grp.h
libpg_query/src/postgres/include/port/win32/netdb.h
libpg_query/src/postgres/include/port/win32/netinet/in.h
libpg_query/src/postgres/include/port/win32/netinet/tcp.h
libpg_query/src/postgres/include/port/win32/pwd.h
libpg_query/src/postgres/include/port/win32/sys/resource.h
libpg_query/src/postgres/include/port/win32/sys/select.h
libpg_query/src/postgres/include/port/win32/sys/socket.h
libpg_query/src/postgres/include/port/win32/sys/un.h
libpg_query/src/postgres/include/port/win32/sys/wait.h
libpg_query/src/postgres/include/port/win32.h
libpg_query/src/postgres/include/port/win32_msvc/dirent.h
libpg_query/src/postgres/include/port/win32_msvc/sys/file.h
libpg_query/src/postgres/include/port/win32_msvc/sys/param.h
libpg_query/src/postgres/include/port/win32_msvc/sys/time.h
libpg_query/src/postgres/include/port/win32_msvc/unistd.h
libpg_query/src/postgres/include/port/win32_msvc/utime.h
libpg_query/src/postgres/include/port/win32_port.h
libpg_query/src/postgres/include/port.h
libpg_query/src/postgres/include/portability/instr_time.h
libpg_query/src/postgres/include/postgres.h
libpg_query/src/postgres/include/postgres_ext.h
libpg_query/src/postgres/include/postmaster/autovacuum.h
libpg_query/src/postgres/include/postmaster/bgworker.h
libpg_query/src/postgres/include/postmaster/bgworker_internals.h
libpg_query/src/postgres/include/postmaster/bgwriter.h
libpg_query/src/postgres/include/postmaster/interrupt.h
libpg_query/src/postgres/include/postmaster/pgarch.h
libpg_query/src/postgres/include/postmaster/postmaster.h
libpg_query/src/postgres/include/postmaster/startup.h
libpg_query/src/postgres/include/postmaster/syslogger.h
libpg_query/src/postgres/include/postmaster/walsummarizer.h
libpg_query/src/postgres/include/postmaster/walwriter.h
libpg_query/src/postgres/include/regex/regex.h
libpg_query/src/postgres/include/replication/logicallauncher.h
libpg_query/src/postgres/include/replication/logicalproto.h
libpg_query/src/postgres/include/replication/logicalworker.h
libpg_query/src/postgres/include/replication/origin.h
libpg_query/src/postgres/include/replication/reorderbuffer.h
libpg_query/src/postgres/include/replication/slot.h
libpg_query/src/postgres/include/replication/slotsync.h
libpg_query/src/postgres/include/replication/syncrep.h
libpg_query/src/postgres/include/replication/walreceiver.h
libpg_query/src/postgres/include/replication/walsender.h
libpg_query/src/postgres/include/rewrite/prs2lock.h
libpg_query/src/postgres/include/rewrite/rewriteHandler.h
libpg_query/src/postgres/include/rewrite/rewriteManip.h
libpg_query/src/postgres/include/rewrite/rewriteSupport.h
libpg_query/src/postgres/include/storage/block.h
libpg_query/src/postgres/include/storage/buf.h
libpg_query/src/postgres/include/storage/bufmgr.h
libpg_query/src/postgres/include/storage/bufpage.h
libpg_query/src/postgres/include/storage/condition_variable.h
libpg_query/src/postgres/include/storage/dsm.h
libpg_query/src/postgres/include/storage/dsm_impl.h
libpg_query/src/postgres/include/storage/fd.h
libpg_query/src/postgres/include/storage/fileset.h
libpg_query/src/postgres/include/storage/ipc.h
libpg_query/src/postgres/include/storage/item.h
libpg_query/src/postgres/include/storage/itemid.h
libpg_query/src/postgres/include/storage/itemptr.h
libpg_query/src/postgres/include/storage/large_object.h
libpg_query/src/postgres/include/storage/latch.h
libpg_query/src/postgres/include/storage/lmgr.h
libpg_query/src/postgres/include/storage/lock.h
libpg_query/src/postgres/include/storage/lockdefs.h
libpg_query/src/postgres/include/storage/lwlock.h
libpg_query/src/postgres/include/storage/lwlocknames.h
libpg_query/src/postgres/include/storage/off.h
libpg_query/src/postgres/include/storage/pg_sema.h
libpg_query/src/postgres/include/storage/pg_shmem.h
libpg_query/src/postgres/include/storage/pmsignal.h
libpg_query/src/postgres/include/storage/predicate.h
libpg_query/src/postgres/include/storage/proc.h
libpg_query/src/postgres/include/storage/procarray.h
libpg_query/src/postgres/include/storage/proclist_types.h
libpg_query/src/postgres/include/storage/procnumber.h
libpg_query/src/postgres/include/storage/procsignal.h
libpg_query/src/postgres/include/storage/read_stream.h
libpg_query/src/postgres/include/storage/relfilelocator.h
libpg_query/src/postgres/include/storage/s_lock.h
libpg_query/src/postgres/include/storage/sharedfileset.h
libpg_query/src/postgres/include/storage/shm_mq.h
libpg_query/src/postgres/include/storage/shm_toc.h
libpg_query/src/postgres/include/storage/shmem.h
libpg_query/src/postgres/include/storage/sinval.h
libpg_query/src/postgres/include/storage/smgr.h
libpg_query/src/postgres/include/storage/spin.h
libpg_query/src/postgres/include/storage/standby.h
libpg_query/src/postgres/include/storage/standbydefs.h
libpg_query/src/postgres/include/storage/sync.h
libpg_query/src/postgres/include/tcop/cmdtag.h
libpg_query/src/postgres/include/tcop/cmdtaglist.h
libpg_query/src/postgres/include/tcop/deparse_utility.h
libpg_query/src/postgres/include/tcop/dest.h
libpg_query/src/postgres/include/tcop/fastpath.h
libpg_query/src/postgres/include/tcop/pquery.h
libpg_query/src/postgres/include/tcop/tcopprot.h
libpg_query/src/postgres/include/tcop/utility.h
libpg_query/src/postgres/include/tsearch/ts_cache.h
libpg_query/src/postgres/include/utils/acl.h
libpg_query/src/postgres/include/utils/aclchk_internal.h
libpg_query/src/postgres/include/utils/array.h
libpg_query/src/postgres/include/utils/ascii.h
libpg_query/src/postgres/include/utils/backend_progress.h
libpg_query/src/postgres/include/utils/backend_status.h
libpg_query/src/postgres/include/utils/builtins.h
libpg_query/src/postgres/include/utils/bytea.h
libpg_query/src/postgres/include/utils/catcache.h
libpg_query/src/postgres/include/utils/date.h
libpg_query/src/postgres/include/utils/datetime.h
libpg_query/src/postgres/include/utils/datum.h
libpg_query/src/postgres/include/utils/dsa.h
libpg_query/src/postgres/include/utils/elog.h
libpg_query/src/postgres/include/utils/errcodes.h
libpg_query/src/postgres/include/utils/expandeddatum.h
libpg_query/src/postgres/include/utils/expandedrecord.h
libpg_query/src/postgres/include/utils/float.h
libpg_query/src/postgres/include/utils/fmgroids.h
libpg_query/src/postgres/include/utils/fmgrprotos.h
libpg_query/src/postgres/include/utils/fmgrtab.h
libpg_query/src/postgres/include/utils/guc.h
libpg_query/src/postgres/include/utils/guc_hooks.h
libpg_query/src/postgres/include/utils/guc_tables.h
libpg_query/src/postgres/include/utils/hsearch.h
libpg_query/src/postgres/include/utils/injection_point.h
libpg_query/src/postgres/include/utils/inval.h
libpg_query/src/postgres/include/utils/logtape.h
libpg_query/src/postgres/include/utils/lsyscache.h
libpg_query/src/postgres/include/utils/memdebug.h
libpg_query/src/postgres/include/utils/memutils.h
libpg_query/src/postgres/include/utils/memutils_internal.h
libpg_query/src/postgres/include/utils/memutils_memorychunk.h
libpg_query/src/postgres/include/utils/numeric.h
libpg_query/src/postgres/include/utils/palloc.h
libpg_query/src/postgres/include/utils/partcache.h
libpg_query/src/postgres/include/utils/pg_locale.h
libpg_query/src/postgres/include/utils/pgstat_internal.h
libpg_query/src/postgres/include/utils/plancache.h
libpg_query/src/postgres/include/utils/portal.h
libpg_query/src/postgres/include/utils/probes.h
libpg_query/src/postgres/include/utils/ps_status.h
libpg_query/src/postgres/include/utils/queryenvironment.h
libpg_query/src/postgres/include/utils/regproc.h
libpg_query/src/postgres/include/utils/rel.h
libpg_query/src/postgres/include/utils/relcache.h
libpg_query/src/postgres/include/utils/reltrigger.h
libpg_query/src/postgres/include/utils/resowner.h
libpg_query/src/postgres/include/utils/ruleutils.h
libpg_query/src/postgres/include/utils/sharedtuplestore.h
libpg_query/src/postgres/include/utils/snapmgr.h
libpg_query/src/postgres/include/utils/snapshot.h
libpg_query/src/postgres/include/utils/sortsupport.h
libpg_query/src/postgres/include/utils/syscache.h
libpg_query/src/postgres/include/utils/timeout.h
libpg_query/src/postgres/include/utils/timestamp.h
libpg_query/src/postgres/include/utils/tuplesort.h
libpg_query/src/postgres/include/utils/tuplestore.h
libpg_query/src/postgres/include/utils/typcache.h
libpg_query/src/postgres/include/utils/varlena.h
libpg_query/src/postgres/include/utils/wait_event.h
libpg_query/src/postgres/include/utils/wait_event_types.h
libpg_query/src/postgres/include/utils/xml.h
libpg_query/src/postgres/include/varatt.h
libpg_query/src/postgres/src_common_kwlist_d.h
libpg_query/src/postgres/src_pl_plpgsql_src_pl_reserved_kwlist_d.h
libpg_query/src/postgres/src_pl_plpgsql_src_pl_unreserved_kwlist_d.h
libpg_query/src/postgres_deparse.c
libpg_query/src/postgres_deparse.h
libpg_query/vendor/protobuf-c/protobuf-c.c
libpg_query/vendor/protobuf-c/protobuf-c.h
libpg_query/vendor/xxhash/xxhash.c
libpg_query/vendor/xxhash/xxhash.h
src/bindings.rs
src/error.rs
src/lib.rs
src/node_enum.rs
src/node_mut.rs
src/node_ref.rs
src/node_structs.rs
src/parse_result.rs
src/protobuf.rs
src/query.rs
src/truncate.rs