### PR TITLE
Exclude pg_query.pb-c.o from package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ include = [
     # libpg_query
     "Makefile", "pg_query.h",
     "libpg_query/{src,vendor}/**/*.{c,h}",
-    "libpg_query/protobuf/{pg_query.pb-c.*,pg_query.proto}",
+    "libpg_query/protobuf/pg_query.pb-c.{c,h}",
+    "libpg_query/protobuf/pg_query.proto",
 ]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
This is listed in the libpg_query gitignore file, but was accidentally included in the cargo package, resulting in this error:

```
cargo package
error: 1 files in the working directory contain changes that were not yet committed into git:

libpg_query/protobuf/pg_query.pb-c.o

to proceed despite this and include the uncommitted changes, pass the `--allow-dirty` flag