### PR TITLE
Introduce basic MERGE support

### DIFF
--- a/src/node_enum.rs
+++ b/src/node_enum.rs
@@ -166,6 +166,34 @@ impl NodeEnum {
                         }
                     });
                 }
+                NodeRef::MergeStmt(m) => {
+                    if let Some(t) = m.relation.as_ref() {
+                        iter.push((t.to_ref(), depth, Context::DML, false));
+                    }
+
+                    m.source_relation.iter().for_each(|n| {
+                        if let Some(n) = n.node.as_ref() {
+                            iter.push((n.to_ref(), depth, Context::DML, false));
+                        }
+                    });
+                    m.merge_when_clauses.iter().for_each(|n| {
+                        if let Some(n) = n.node.as_ref() {
+                            iter.push((n.to_ref(), depth, Context::DML, true));
+                        }
+                    });
+                    m.join_condition.iter().for_each(|n| {
+                        if let Some(n) = n.node.as_ref() {
+                            iter.push((n.to_ref(), depth, Context::Select, false));
+                        }
+                    });
+                    if let Some(clause) = m.with_clause.as_ref() {
+                        clause.ctes.iter().for_each(|n| {
+                            if let Some(n) = n.node.as_ref() {
+                                iter.push((n.to_ref(), depth, Context::Select, false));
+                            }
+                        });
+                    }
+                }
                 NodeRef::CommonTableExpr(s) => {
                     if let Some(n) = &s.ctequery {
                         if let Some(n) = n.node.as_ref() {

--- a/src/parse_result.rs
+++ b/src/parse_result.rs
@@ -276,6 +276,7 @@ impl ParseResult {
                 Some(NodeEnum::DeleteStmt(..)) => Some("DeleteStmt"),
                 Some(NodeEnum::UpdateStmt(..)) => Some("UpdateStmt"),
                 Some(NodeEnum::SelectStmt(..)) => Some("SelectStmt"),
+                Some(NodeEnum::MergeStmt(..)) => Some("MergeStmt"),
                 Some(NodeEnum::AlterTableStmt(..)) => Some("AlterTableStmt"),
                 Some(NodeEnum::AlterTableCmd(..)) => Some("AlterTableCmd"),
                 Some(NodeEnum::AlterDomainStmt(..)) => Some("AlterDomainStmt"),

--- a/tests/parse_tests.rs
+++ b/tests/parse_tests.rs
@@ -285,6 +285,20 @@ fn it_parses_VACUUM() {
 }
 
 #[test]
+fn it_parses_MERGE() {
+    let result = parse(
+        "MERGE INTO my_table USING g.other_table ON (id=oid) WHEN MATCHED THEN UPDATE SET a=b WHEN NOT MATCHED THEN INSERT (id, a) VALUES (oid, b);",
+    )
+    .unwrap();
+    assert_eq!(result.warnings.len(), 0);
+
+    let tables: Vec<String> = sorted(result.tables()).collect();
+    assert_eq!(tables, ["g.other_table", "my_table"]);
+    assert_eq!(result.statement_types(), ["MergeStmt"]);
+    cast!(result.protobuf.nodes()[0].0, NodeRef::MergeStmt);
+}
+
+#[test]
 fn it_parses_EXPLAIN() {
     let result = parse("EXPLAIN DELETE FROM test").unwrap();
     assert_eq!(result.warnings.len(), 0);


### PR DESCRIPTION
Previously, when calling tables() on a merge statement, the list would be empty. This commit does not attempt to be exhaustive, but tries to ensure that those nodes in Merge statemens also get iterated over.