### PR TITLE
Bugfix: Parsing Merge tables/ctes

### DIFF
--- a/src/node_enum.rs
+++ b/src/node_enum.rs
@@ -171,9 +171,17 @@ impl NodeEnum {
                         iter.push((t.to_ref(), depth, Context::DML, false));
                     }
 
+                    if let Some(clause) = &m.with_clause {
+                        clause.ctes.iter().for_each(|n| {
+                            if let Some(n) = n.node.as_ref() {
+                                iter.push((n.to_ref(), depth, Context::DML, false));
+                            }
+                        });
+                    }
+
                     m.source_relation.iter().for_each(|n| {
                         if let Some(n) = n.node.as_ref() {
-                            iter.push((n.to_ref(), depth, Context::DML, false));
+                            iter.push((n.to_ref(), depth, Context::Select, false));
                         }
                     });
                     m.merge_when_clauses.iter().for_each(|n| {
@@ -186,13 +194,6 @@ impl NodeEnum {
                             iter.push((n.to_ref(), depth, Context::Select, false));
                         }
                     });
-                    if let Some(clause) = m.with_clause.as_ref() {
-                        clause.ctes.iter().for_each(|n| {
-                            if let Some(n) = n.node.as_ref() {
-                                iter.push((n.to_ref(), depth, Context::Select, false));
-                            }
-                        });
-                    }
                 }
                 NodeRef::CommonTableExpr(s) => {
                     if let Some(n) = &s.ctequery {

--- a/tests/parse_tests.rs
+++ b/tests/parse_tests.rs
@@ -287,14 +287,23 @@ fn it_parses_VACUUM() {
 #[test]
 fn it_parses_MERGE() {
     let result = parse(
-        "MERGE INTO my_table USING g.other_table ON (id=oid) WHEN MATCHED THEN UPDATE SET a=b WHEN NOT MATCHED THEN INSERT (id, a) VALUES (oid, b);",
+        "WITH cte AS (SELECT * FROM g.other_table CROSS JOIN p) MERGE INTO my_table USING cte ON (id=oid) WHEN MATCHED THEN UPDATE SET a=b WHEN NOT MATCHED THEN INSERT (id, a) VALUES (oid, b);",
     )
     .unwrap();
     assert_eq!(result.warnings.len(), 0);
 
-    let tables: Vec<String> = sorted(result.tables()).collect();
-    assert_eq!(tables, ["g.other_table", "my_table"]);
+    let select_tables: Vec<String> = sorted(result.select_tables()).collect();
+    assert_eq!(select_tables, ["g.other_table", "p"]);
+
+    let dml_tables: Vec<String> = sorted(result.dml_tables()).collect();
+    assert_eq!(dml_tables, ["my_table"]);
+
+    let all_tables: Vec<String> = sorted(result.tables()).collect();
+    assert_eq!(all_tables, ["g.other_table", "my_table", "p"]);
+
+    assert_eq!(result.cte_names, ["cte"]);
     assert_eq!(result.statement_types(), ["MergeStmt"]);
+
     cast!(result.protobuf.nodes()[0].0, NodeRef::MergeStmt);
 }
 


### PR DESCRIPTION
> 😅 I didn't expect the previous PR to be merged that fast. While doing some further tests, I found a few subtle bugs with it, which this PR attempts to address.

Errata for 42a650c8

We (incorrectly) marked the source table as having a DML context. The CTE names were also considered to be select_tables, which should not happen, by ensuring CTE's get evaluated before other clauses, we fix that.

