### PR TITLE
Remove tests that are testing the standard library

### DIFF
--- a/tests/summary_truncate_tests.rs
+++ b/tests/summary_truncate_tests.rs
@@ -114,12 +114,3 @@ fn char_truncate_works() {
     let output = "WITH \"原チコ氏にはす腹腹腹腹腹...";
     assert_eq!(result.truncated_query, output);
 }
-
-#[test]
-#[should_panic(
-    expected = "byte index 22 is not a char boundary; it is inside 'は' (bytes 21..24) of `WITH \"原チコ氏にはす腹腹腹腹腹腹腹腹腹腹腹\" AS (SELECT) SELECT w`"
-)]
-fn byte_truncate_fails() {
-    let query = "WITH \"原チコ氏にはす腹腹腹腹腹腹腹腹腹腹腹\" AS (SELECT) SELECT w".to_string();
-    query[0..=21].to_string();
-}

--- a/tests/truncate_tests.rs
+++ b/tests/truncate_tests.rs
@@ -116,12 +116,3 @@ fn char_truncate_works() {
     let output = "WITH \"原チコ氏にはす腹腹腹腹腹...";
     assert_eq!(result.truncate(21).unwrap(), output);
 }
-
-#[test]
-#[should_panic(
-    expected = "byte index 22 is not a char boundary; it is inside 'は' (bytes 21..24) of `WITH \"原チコ氏にはす腹腹腹腹腹腹腹腹腹腹腹\" AS (SELECT) SELECT w`"
-)]
-fn byte_truncate_fails() {
-    let query = "WITH \"原チコ氏にはす腹腹腹腹腹腹腹腹腹腹腹\" AS (SELECT) SELECT w".to_string();
-    query[0..=21].to_string();
-}


### PR DESCRIPTION
These tests never call into code from the pg_query crate. They are purely testing the standard library's behavior, and have begun failing due to a change in the error message in std