### PR TITLE
Propagate real bindgen error in build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -70,7 +70,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     bindgen::Builder::default()
         .header(out_header_path.to_str().ok_or("Invalid header path")?)
         .generate()
-        .map_err(|_| "Unable to generate bindings")?
+        .map_err(|e| format!("Unable to generate bindings: {e}"))?
         .write_to_file(out_dir.join("bindings.rs"))?;
 
     // Only generate protobuf bindings if protoc is available


### PR DESCRIPTION
Fixes #80

`build.rs` generated bindings with `.map_err(|_| "Unable to generate bindings")?`, which discarded the underlying `bindgen::BindgenError` (and the clang diagnostics it carries). When bindgen fails — e.g. cross-compiling to a target whose libc headers aren't on clang's default search path — the build died with only the opaque string "Unable to generate bindings", with no indication of what actually went wrong.

This includes the real error in the message, so bindgen/clang failures are debuggable instead of requiring a from-source investigation.